### PR TITLE
Add max-width to footer

### DIFF
--- a/src/containers/home/home.scss
+++ b/src/containers/home/home.scss
@@ -86,6 +86,7 @@
     &-footer {
       margin-top: 40px;
       width: 100vw;
+      max-width: 100%;
       background: #f2f2f3;
       padding: 20px 0;
       color: gray;


### PR DESCRIPTION
Footer's width is set to `width: 100vw;` so if there's a vertical scrolling bar on the screen, the footer will be wider that the screen itself.
Adding `max-width` fixes this issue.